### PR TITLE
Add pywin32 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ deep_translator
 babel
 pywebview
 matplotlib
+pywin32


### PR DESCRIPTION
Fix truckersmp lock error:
('DLL load failed while importing win32gui: The specified module could not be found.',)